### PR TITLE
Ignore files in base directory

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -32,7 +32,9 @@ module.exports = function (basePath) {
     if (!paths.length) {
       throw new Error('Unable to find version directorys within \'' + basePath + '\'');
     }
-    requireCache[basePath].versions = paths.sort(compare);
+    requireCache[basePath].versions = paths.filter(function (target) {
+      return fs.statSync(path.join(basePath, target)).isDirectory();
+    }).sort(compare);
   }
   versions = requireCache[basePath].versions;
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,10 +9,12 @@ module.exports = {
   setUp: function (cb) {
     var basePath = path.join(__dirname, 'versions');
     mkdirp(path.join(basePath, 'v1'), function () {
-      fs.writeFile(path.join(basePath, 'v1', 'test.js'), '', function (err) {
-        mkdirp(path.join(basePath, 'v1.1'), function () {
-          mkdirp(path.join(basePath, 'v2'), function () {
-            mkdirp(path.join(__dirname, 'empty'), cb);
+      fs.writeFile(path.join(basePath, 'test.js'), '', function (err) {
+        fs.writeFile(path.join(basePath, 'v1', 'test.js'), '', function (err) {
+          mkdirp(path.join(basePath, 'v1.1'), function () {
+            mkdirp(path.join(basePath, 'v2'), function () {
+              mkdirp(path.join(__dirname, 'empty'), cb);
+            });
           });
         });
       });


### PR DESCRIPTION
Files in the base directory fail the version comparison. In order to make the module a little more flexible we'll explicitly pull out directories within the base directory and use those as candidate
version directories.
